### PR TITLE
Make Zombie Spores more dangerous

### DIFF
--- a/DiseasesReimagined/MoreEvilFlower.cs
+++ b/DiseasesReimagined/MoreEvilFlower.cs
@@ -1,0 +1,47 @@
+﻿using Klei;
+using UnityEngine;
+
+namespace DiseasesReimagined
+{
+    // Makes zombie flowers even more evil if wild, causing them to spread spores into the
+    // tile on which they stand.
+    public sealed class MoreEvilFlower : KMonoBehaviour, ISim4000ms
+    {
+        // How many germs per second to infect the tile it is standing on.
+        private const float GERMS_PER_SECOND = 1000.0f;
+
+        // The cached disease index to use for infection.
+        private byte disease = SimUtil.DiseaseInfo.Invalid.idx;
+
+        // These are populated automatically
+#pragma warning disable IDE0044 // Add readonly modifier
+        [MyCmpGet]
+        private WiltCondition isWilted;
+
+        [MyCmpGet]
+        private UprootedMonitor uprooted;
+#pragma warning restore IDE0044 // Add readonly modifier
+
+        protected override void OnSpawn()
+        {
+            base.OnSpawn();
+            disease = Db.Get().Diseases.GetIndex("ZombieSpores");
+        }
+
+        public void Sim4000ms(float dt)
+        {
+            var obj = gameObject;
+            int cell;
+            if (obj != null && Grid.IsValidCell(cell = Grid.PosToCell(obj)) && isWilted?.
+                IsWilting() == false && disease != SimUtil.DiseaseInfo.Invalid.idx &&
+                uprooted != null)
+            {
+                cell = Grid.OffsetCell(cell, uprooted.monitorCell);
+                if (Grid.IsValidCell(cell) && Grid.Solid[cell])
+                    // Flower is growing and on a solid cell, infect it!
+                    SimMessages.ModifyDiseaseOnCell(cell, disease, Mathf.RoundToInt(
+                        GERMS_PER_SECOND / dt));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Zombie Spores is much more dangerous. It can spread across solid tiles at fairly moderate concentrations, and survives on lead and iron ore. It also is now emitted by wild Sporechids on the tile where they are planted, so that the solids in the nearby area become infected. Abyssalite and Neutronium disinfect zombie spores on them.

Some testing is still needed to see if the infection becomes too powerful.

Fix todo list #9 all harmful germs die on plastic.