### PR TITLE
Emote/sink bug fix and compatibility with Queue for Sinks

### DIFF
--- a/DiseasesReimagined/CompatPatch.cs
+++ b/DiseasesReimagined/CompatPatch.cs
@@ -1,0 +1,50 @@
+﻿using Harmony;
+using PeterHan.PLib;
+using System;
+using UnityEngine;
+
+namespace DiseasesReimagined
+{
+    // Patches for cross-mod compatibility
+    public static class CompatPatch
+    {
+        internal static void CompatPatches(HarmonyInstance instance)
+        {
+#if DEBUG
+            PUtil.LogDebug("Starting compatibility patches");
+#endif
+            // QfS: observe cooldown
+            try
+            {
+                var sinkType = Type.GetType("PeterHan.QueueForSinks.SinkCheckpoint, QueueForSink",
+                    false);
+                if (sinkType != null)
+                {
+                    PUtil.LogDebug("Compatibility patching for Queue for Sinks");
+                    instance.Patch(sinkType, "MustStop", null, new HarmonyMethod(
+                        typeof(CompatPatch), nameof(MustStop_Postfix)));
+                }
+            }
+            catch (TypeLoadException)
+            {
+                // Ignore
+#if DEBUG
+                PUtil.LogDebug("Queue For Sinks not found.");
+#endif
+            }
+            catch (Exception e)
+            {
+                PUtil.LogExcWarn(e);
+            }
+        }
+
+        private static void MustStop_Postfix(GameObject reactor, ref bool __result)
+        {
+            // Prevent OCD hand washing by allowing duplicants who cannot use a sink again to
+            // pass QfS
+            var cooldown = reactor.GetComponent<WashCooldownComponent>();
+            if (cooldown != null && !cooldown.CanWash)
+                __result = false;
+        }
+    }
+}

--- a/DiseasesReimagined/DiseasesPatch.cs
+++ b/DiseasesReimagined/DiseasesPatch.cs
@@ -32,6 +32,9 @@ namespace DiseasesReimagined
                 SkipNotifications.Skip(SlimeLethalSickness.ID);
                 SkipNotifications.Skip(SlimeCoughSickness.ID);
                 SkipNotifications.Skip(FoodPoisonVomiting.ID);
+
+                PUtil.InitLibrary(false);
+                PUtil.RegisterPostload(CompatPatch.CompatPatches);
             }
             
             // Helper method to find a specific attribute modifier

--- a/DiseasesReimagined/WashCooldownComponent.cs
+++ b/DiseasesReimagined/WashCooldownComponent.cs
@@ -7,7 +7,7 @@ namespace DiseasesReimagined
     public sealed class WashCooldownComponent : MonoBehaviour
     {
         // How long Duplicants must wait before washing again.
-        public const float WASH_COOLDOWN = 3.0f;
+        public const float WASH_COOLDOWN = 6.0f;
 
         public bool CanWash
         {

--- a/DiseasesReimagined/WashCooldownComponent.cs
+++ b/DiseasesReimagined/WashCooldownComponent.cs
@@ -7,7 +7,7 @@ namespace DiseasesReimagined
     public sealed class WashCooldownComponent : MonoBehaviour
     {
         // How long Duplicants must wait before washing again.
-        public const float WASH_COOLDOWN = 0.5f;
+        public const float WASH_COOLDOWN = 3.0f;
 
         public bool CanWash
         {


### PR DESCRIPTION
Fix Diseases: Duplicants who pause for an emote on the sink will not instantly wash their hands again.

Add compatibility patch for "Queue for Sinks" to avoid compulsory hand washing with Duplicants queued.