### PR TITLE
Diseases fix for ugly crier and vomiting cures

### DIFF
--- a/DiseasesReimagined/AddSicknessComponent.cs
+++ b/DiseasesReimagined/AddSicknessComponent.cs
@@ -3,26 +3,42 @@ using UnityEngine;
 
 namespace DiseasesReimagined
 {
-    class AddSicknessComponent : Sickness.SicknessComponent
+    internal class AddSicknessComponent : Sickness.SicknessComponent
     {
-        readonly string infection_source_info;
-        readonly string sickness_id;
+        private readonly string excluded_effect;
+        private readonly string infection_source_info;
+        private readonly string sickness_id;
 
-        public AddSicknessComponent(string sickness_id, string infection_source_info)
+        public AddSicknessComponent(string sickness_id, string infection_source_info,
+            string excluded_effect = "")
         {
+            this.excluded_effect = excluded_effect;
             this.sickness_id = sickness_id;
             this.infection_source_info = infection_source_info;
         }
 
         public override object OnInfect(GameObject go, SicknessInstance diseaseInstance)
         {
-            var exposure_info = new SicknessExposureInfo(sickness_id, infection_source_info);
-            go.GetComponent<MinionModifiers>().sicknesses.Infect(exposure_info);
+            if (go != null)
+                GameScheduler.Instance.Schedule("InfectWith" + sickness_id, 0.5f, (_) =>
+                {
+                    var effects = go.GetComponent<Effects>();
+                    // Do not inflict the symptoms if the excluded effect is present
+                    if (effects == null || string.IsNullOrEmpty(excluded_effect) || !effects.
+                        HasEffect(excluded_effect))
+                    {
+                        var exposure_info = new SicknessExposureInfo(sickness_id,
+                            infection_source_info);
+                        go.GetComponent<MinionModifiers>()?.sicknesses?.Infect(exposure_info);
+                    }
+                });
             return null;
         }
 
         public override void OnCure(GameObject go, object instance_data)
         {
+            // Cure the added sickness if the original disease gets cured
+            go.GetComponent<MinionModifiers>()?.sicknesses?.Cure(sickness_id);
         }
     }
 }

--- a/DiseasesReimagined/DiseasesReimagined.csproj
+++ b/DiseasesReimagined/DiseasesReimagined.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
     <AssemblyTitle>Diseases Reimagined</AssemblyTitle>
-    <Version>1.1.0.0</Version>
+    <Version>1.2.0.0</Version>
     <UsesPLib>true</UsesPLib>
   </PropertyGroup>
 </Project>

--- a/DiseasesReimagined/FrostbitePatch.cs
+++ b/DiseasesReimagined/FrostbitePatch.cs
@@ -37,7 +37,7 @@ namespace DiseasesReimagined
             }
         }
 
-        // Gets the average external pressure of the cells occupied by the creature
+        // Gets the minimum external pressure of the cells occupied by the creature
         public static float GetCurrentExternalPressure(ExternalTemperatureMonitor.Instance instance)
         {
             int cell = Grid.PosToCell(instance.gameObject);
@@ -46,17 +46,16 @@ namespace DiseasesReimagined
             if (area != null)
             {
                 float total = 0f;
-                int n = 0;
                 foreach (CellOffset offset in area.OccupiedCellsOffsets)
                 {
                     int newCell = Grid.OffsetCell(cell, offset);
                     if (Grid.IsValidCell(newCell))
                     {
-                        total += Grid.Pressure[newCell];
-                        n++;
+                        float newPressure = Grid.Pressure[newCell];
+                        if (newPressure < pressure)
+                            pressure = newPressure;
                     }
                 }
-                pressure = total / System.Math.Max(1.0f, n);
             }
             return pressure;
         }
@@ -96,7 +95,7 @@ namespace DiseasesReimagined
                 // a bit of a kludge, because for some reason Average External Temperature
                 // does not update for Frostbite even though it does for Scalding.
                 var exttemp = data.GetCurrentExternalTemperature;
-                return exttemp < GetFrostbiteThreshold(data) &&
+                return exttemp < GetFrostbiteThreshold(data) && exttemp > 0.01f &&
                     GetCurrentExternalPressure(data) >= GermExposureTuning.MIN_PRESSURE;
             }
 

--- a/DiseasesReimagined/GermExposureTuning.cs
+++ b/DiseasesReimagined/GermExposureTuning.cs
@@ -20,7 +20,7 @@ namespace DiseasesReimagined
         internal const int FP_GERMS_VOMITED = 10000;
 
         // How many seconds between vomits when Food Poisoning is left untreated
-        internal const float FP_VOMIT_INTERVAL = 120.0f;
+        internal const float FP_VOMIT_INTERVAL = 200.0f;
 
         // The germ resistance debuff when Dead Tired.
         internal const float GERM_RESIST_TIRED = -1.0f;

--- a/DiseasesReimagined/SlimeCoughSickness.cs
+++ b/DiseasesReimagined/SlimeCoughSickness.cs
@@ -12,7 +12,7 @@ namespace DiseasesReimagined
                 new List<InfectionVector>
                 {
                     InfectionVector.Inhalation
-                }, 3600f)
+                }, 3690f)
         {
             AddSicknessComponent(new SlimeSickness.SlimeLungComponent());
         }

--- a/DiseasesReimagined/VomitComponent.cs
+++ b/DiseasesReimagined/VomitComponent.cs
@@ -10,11 +10,10 @@ namespace DiseasesReimagined
     public class FoodPoisonVomiting : Sickness
     {
         public const string ID = "FoodPoisonVomiting";
-        public const string RECOVERY_ID = null; // don't need an immunity effect for a symptom
         public static List<InfectionVector> vectors = new List<InfectionVector>(new[] {InfectionVector.Digestion});
 
         public FoodPoisonVomiting()
-            : base(ID, SicknessType.Ailment, Severity.Minor, 1f, vectors, 1020f)
+            : base(ID, SicknessType.Ailment, Severity.Minor, 1f, vectors, 1019f)
         {
             AddSicknessComponent(new VomitComponent());
             AddSicknessComponent(new ModifyParentTimeComponent(FoodSickness.ID, .8f));
@@ -36,15 +35,16 @@ namespace DiseasesReimagined
 
         public override void OnCure(GameObject go, object instance_data)
         {
-            ((StateMachine.Instance) instance_data).StopSM("Cured");
+            (instance_data as StateMachine.Instance)?.StopSM("Cured");
         }
 
         public override List<Descriptor> GetSymptoms()
         {
             return new List<Descriptor>
             {
-                new Descriptor("Vomiting", DUPLICANTS.DISEASES.FOODSICKNESS.
-                    VOMIT_SYMPTOM_TOOLTIP, Descriptor.DescriptorType.SymptomAidable)
+                new Descriptor(DUPLICANTS.DISEASES.FOODSICKNESS.VOMIT_SYMPTOM, DUPLICANTS.
+                    DISEASES.FOODSICKNESS.VOMIT_SYMPTOM_TOOLTIP, Descriptor.DescriptorType.
+                    SymptomAidable)
             };
         }
 
@@ -101,14 +101,14 @@ namespace DiseasesReimagined
                 Vomit.DefaultState(Vomit.normal);
                 Vomit.normal.Enter("SetVomitTime", smi =>
                 {
-                    if (smi.lastVomitTime >= Time.time)
+                    float time = Time.time;
+                    if (smi.lastVomitTime >= time)
                         return;
-                    smi.lastVomitTime = Time.time;
+                    smi.lastVomitTime = time;
                 }).Update("Vomit", (smi, dt) =>
                 {
-                    if (Time.time - smi.lastVomitTime <= GermExposureTuning.FP_VOMIT_INTERVAL)
-                        return;
-                    smi.GoTo(Vomit.vomit);
+                    if (Time.time - smi.lastVomitTime > GermExposureTuning.FP_VOMIT_INTERVAL)
+                        smi.GoTo(Vomit.vomit);
                 }, UpdateRate.SIM_4000ms);
                 Vomit.vomit.Enter("DoTheVomit", smi => { smi.Vomit(smi.GetMaster().gameObject); })
                      .OnSignal(vomitFinished, Vomit.normal);


### PR DESCRIPTION
Fix Diseases: Duplicate copies of sicknesses are no longer added on reload. Frostbite check now uses min pressure to avoid killing ugly criers.