### PR TITLE
Fix #25: Persistent Coughing and Vomiting

### DIFF
--- a/DiseasesReimagined/AddSicknessComponent.cs
+++ b/DiseasesReimagined/AddSicknessComponent.cs
@@ -19,7 +19,7 @@ namespace DiseasesReimagined
 
         public override object OnInfect(GameObject go, SicknessInstance diseaseInstance)
         {
-            if (go != null)
+            if (go != null && diseaseInstance.GetPercentCured() < 0.01f)
                 GameScheduler.Instance.Schedule("InfectWith" + sickness_id, 0.5f, (_) =>
                 {
                     var effects = go.GetComponent<Effects>();


### PR DESCRIPTION
Diseases will only add sub-diseases if they were very recently infected.

Untested, constant value may need to be tuned, especially on ultra speed.