### PR TITLE
Reduce log spam from Diseases Reimagined on Floral Scents

### DIFF
--- a/DiseasesReimagined/DiseasesPatch.cs
+++ b/DiseasesReimagined/DiseasesPatch.cs
@@ -7,7 +7,6 @@ using ReimaginationTeam.Reimagination;
 using STRINGS;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using static SkyLib.Logger;
 using static SkyLib.OniUtils;
@@ -87,14 +86,15 @@ namespace DiseasesReimagined
                 var docStation = Traverse.Create(__instance);
                 ___treatments_available.Clear();
 
-                foreach (var tag in ___storage.items.Where(go => go.HasTag(GameTags.MedicalSupplies))
-                                              .Select(go => go.PrefabID()))
-                {
-                    if (tag == "IntermediateCure")
-                        docStation.CallMethod("AddTreatment", SlimeLethalSickness.ID, tag);
-                    if (tag == "AdvancedCure")
-                        docStation.CallMethod("AddTreatment", ZombieSickness.ID, tag);
-                }
+                foreach (var go in ___storage.items)
+                    if (go.HasTag(GameTags.MedicalSupplies))
+                    {
+                        var tag = go.PrefabID();
+                        if (tag == "IntermediateCure")
+                            docStation.CallMethod("AddTreatment", SlimeLethalSickness.ID, tag);
+                        if (tag == "AdvancedCure")
+                            docStation.CallMethod("AddTreatment", ZombieSickness.ID, tag);
+                    }
 
                 ___smi.sm.hasSupplies.Set(___treatments_available.Count > 0, ___smi);
 

--- a/DiseasesReimagined/GermIntegrator.cs
+++ b/DiseasesReimagined/GermIntegrator.cs
@@ -93,7 +93,7 @@ namespace DiseasesReimagined
                     total += count;
                 else
                     total = count;
-#if false
+#if DEBUG
                 PUtil.LogDebug("{0} has {1:D} germs of {2} by {3} (threshold = {4:D})".F(
                     gameObject.name, count, germ, ge.Vector, threshold));
 #endif
@@ -115,7 +115,9 @@ namespace DiseasesReimagined
                         if (exposure.infect_immediately)
                         {
                             // The ultimate evil flag
+#if DEBUG
                             PUtil.LogDebug("Infecting {0} with {1}".F(gameObject.name, germ));
+#endif
                             monitor.InfectImmediately(exposure);
                         }
                         else
@@ -123,7 +125,7 @@ namespace DiseasesReimagined
                             // "Exposed to slimelung"
                             monitor.SetExposureState(germ, ExposureState.Exposed);
                             monitor.SetExposureTier(germ, tier);
-#if false
+#if DEBUG
                             PUtil.LogDebug("{0} exposed to {1} tier {2:F1}".F(gameObject.name,
                                 germ, tier));
 #endif
@@ -138,7 +140,7 @@ namespace DiseasesReimagined
                     if (total > threshold && tier > monitor.GetExposureTier(germ))
                     {
                         monitor.SetExposureTier(germ, tier);
-#if false
+#if DEBUG
                         PUtil.LogDebug("{0} exposure of {1} upgraded to {2:F1}".F(gameObject.
                             name, germ, tier));
 #endif
@@ -324,7 +326,9 @@ namespace DiseasesReimagined
                             GetInfectionChance(ge, total, GetResistance(exposure)))
                         {
                             // Gotcha!
+#if DEBUG
                             PUtil.LogDebug("Infecting {0} with {1}".F(gameObject.name, germ));
+#endif
                             monitor.SetExposureState(germ, ExposureState.Sick);
                             monitor.InfectImmediately(exposure);
                         }


### PR DESCRIPTION
Move some log statements to debug-only to reduce log spam related to repeated "infections" with Floral Scents.