### PR TITLE
Allow pod to store food

### DIFF
--- a/StoragePod/StoragePodConfig.cs
+++ b/StoragePod/StoragePodConfig.cs
@@ -43,7 +43,13 @@ namespace StoragePod
             storage.showInUI = true;
             storage.allowItemRemoval = true;
             storage.showDescriptor = true;
-            storage.storageFilters = STORAGEFILTERS.NOT_EDIBLE_SOLIDS;
+            System.Collections.Generic.List<Tag> storedItems = new System.Collections.Generic.List<Tag>();
+            storedItems.AddRange(STORAGEFILTERS.NOT_EDIBLE_SOLIDS);
+            if (StoragePodOptions.Instance.podStoresFood)
+            {
+                storedItems.AddRange(STORAGEFILTERS.FOOD);
+            }
+            storage.storageFilters = storedItems;
             storage.storageFullMargin = STORAGE.STORAGE_LOCKER_FILLED_MARGIN;
             storage.fetchCategory = Storage.FetchCategory.GeneralStorage;
             storage.allowSublimation = false;

--- a/StoragePod/StoragePodPatch.cs
+++ b/StoragePod/StoragePodPatch.cs
@@ -14,6 +14,7 @@ namespace StoragePod
         {
             podCapacity = 5000f;
             coolPodCapacity = 50f;
+            podStoresFood = false;
         }
 
         [Option("Pod Capacity", "How many kg of Solids a Storage Pod can store.")]
@@ -23,6 +24,10 @@ namespace StoragePod
         [Option("Cool Pod Capacity", "How many kg of Solids a Cool Pod can store.")]
         [JsonProperty]
         public float coolPodCapacity { get; set; }
+
+        [Option("Pod Stores Food", "Can you store food in a Storage Pod?")]
+        [JsonProperty]
+        public bool podStoresFood { get; set; }
     }
 
     public class StoragePodPatch


### PR DESCRIPTION
Based on request in the Steam comments (and my own need for a wall mounted food storage device), added an option to allow food storage in the pod (defaults off to preserve current behavior, to enable add `"podStoresFood":true` to config.json).