### PR TITLE
Remove germs from the irrigant after transferring to the plant.

### DIFF
--- a/DiseasesReimagined/PlantsPatch.cs
+++ b/DiseasesReimagined/PlantsPatch.cs
@@ -83,8 +83,9 @@ namespace DiseasesReimagined
                     if (disease > 0 && (plant = farmTile.GetComponent<PlantablePlot>()?.
                         Occupant) != null)
                     {
-                        plant.GetComponent<PrimaryElement>()?.AddDisease(irrigant.DiseaseIdx,
-                            Mathf.RoundToInt(required * disease / mass), "Irrigation");
+                        var diseaseCount = Mathf.RoundToInt(required * disease / mass);
+                        plant.GetComponent<PrimaryElement>()?.AddDisease(irrigant.DiseaseIdx, diseaseCount, "Irrigation");
+                        irrigant.ModifyDiseaseCount(-diseaseCount, "Irrigation");
                     }
                     required -= consumed;
                 }


### PR DESCRIPTION
This is a fix for the issue described in #49, where plants being supplied irrigants containing germs would very rapidly grow to millions of germs.  The germs would then be transferred to a duplicant and cause them to become stuck trying to wash the germs off.

This was caused by germs being created on the plant in proportion to the irrigant consumed, but the germs were not removed from the irrigant.  This lead to an ever-increasing number of germs in the irrigant, with a significant multiplier if the irrigant ever came close to running out.

The germ growth on the plant will still grow indefinitely if irrigant is supplied, but at a much lower rate than before.  Each time the plant is harvested the germs are divided between the plant and output (at a reduced rate - not sure how this is calculated.)  This seems like reasonable behavior - the irrigant can be cut off to reduce the germ count if it becomes a problem.