### PR TITLE
Fix for Buff and Shine update.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <Reference Include="UnityEngine.CoreModule" />
   </ItemGroup>
   <ItemGroup Condition=" '$(UsesPLib)' == 'true' ">
-    <PackageReference Include="PLib" Version="4.4.0" />
+    <PackageReference Include="PLib" Version="4.6.0" />
     <Reference Include="Newtonsoft.Json" />
     <Reference Include="Unity.TextMeshPro" />
     <Reference Include="UnityEngine.TextRenderingModule" />


### PR DESCRIPTION
Fixes #69

Compiling with the version 4.6.0 of PLib does the trick.