### PR TITLE
exit if no sicknesses

### DIFF
--- a/DiseasesReimagined/GermExposurePatch.cs
+++ b/DiseasesReimagined/GermExposurePatch.cs
@@ -26,6 +26,9 @@ namespace DiseasesReimagined
         {
             var exposure = GameUtil.GetExposureTypeForDisease(disease);
             var sickness = GameUtil.GetSicknessForDisease(disease);
+            if (sickness == null)
+                return;
+
             ICollection<string> required = exposure.required_traits, excluded = exposure.
                 excluded_traits, noEffects = exposure.excluded_effects;
             var traits = target.GetComponent<Traits>();


### PR DESCRIPTION
New Spaced Out diseases (like Radiation Sickness) do not have "sicknesses" and do not appear on the immune system info panel in vanilla. So exiting early fixes crashing for these cases without changing base functionality. 