### PR TITLE
Remove implicit Logic Input Port from CoolPod

### DIFF
--- a/StoragePod/CoolPodConfig.cs
+++ b/StoragePod/CoolPodConfig.cs
@@ -30,6 +30,7 @@ namespace StoragePod
                 construction_time, tieR4, construction_mats, melting_point, build_location_rule,
                 BUILDINGS.DECOR.PENALTY.TIER1, none);
             buildingDef.RequiresPowerInput = true;
+            buildingDef.AddLogicPowerPort = false;
             buildingDef.EnergyConsumptionWhenActive = 60f;
             buildingDef.ExhaustKilowattsWhenActive = 0.25f;
             buildingDef.LogicOutputPorts = new List<LogicPorts.Port>()


### PR DESCRIPTION
Fixes skairunner/sky-oni-mods#68 (stock Refrigerator also lacks logic input port). At some point the base game started adding an implicit Logic Input Port at 0,0 whenever a building uses power, to enable switching the building on/off. This can be disabled via the AddLogicPowerPort property on the buildingDef. This patch disables this property on the CoolPod.