### PR TITLE
Slime Lethal should be Severity.Critical

### DIFF
--- a/DiseasesReimagined/SlimeLethalSickness.cs
+++ b/DiseasesReimagined/SlimeLethalSickness.cs
@@ -8,7 +8,7 @@ namespace DiseasesReimagined
         public const string ID = "SlimeLethal";
 
         public SlimeLethalSickness()
-            : base(ID, SicknessType.Ailment, Severity.Major, 0.00025f,
+            : base(ID, SicknessType.Ailment, Severity.Critical, 0.00025f,
                 new List<InfectionVector>
                 {
                     InfectionVector.Inhalation


### PR DESCRIPTION
Critical is needed for the sickness tooltip to actually show time until death if untreated (see SicknessInstance.ResolveString()). With Major it always shows time to recovery.