### PR TITLE
Prevent Bionic vomit related crash

### DIFF
--- a/DiseasesReimagined/DiseasesReimagined.csproj
+++ b/DiseasesReimagined/DiseasesReimagined.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net471</TargetFramework>
         <AssemblyTitle>Diseases Reimagined</AssemblyTitle>
-        <Version>1.12.0</Version>
+        <Version>1.13.0</Version>
         <UsesPLib>true</UsesPLib>
     </PropertyGroup>
     <ItemGroup>

--- a/DiseasesReimagined/VomitComponent.cs
+++ b/DiseasesReimagined/VomitComponent.cs
@@ -79,9 +79,13 @@ namespace DiseasesReimagined
                 }
                 // Decrease kcal as well
                 var cals = Db.Get().Amounts.Calories.Lookup(vomiter);
-                float curKcal = cals.value;
-                if (curKcal > GermExposureTuning.KCAL_LOST_VOMIT + 100.0f)
-                    cals.SetValue(curKcal - GermExposureTuning.KCAL_LOST_VOMIT);
+                if (cals != null)
+                {
+                    // Bionic Duplicants do not have kcal
+                    float curKcal = cals.value;
+                    if (curKcal > GermExposureTuning.KCAL_LOST_VOMIT + 100.0f)
+                        cals.SetValue(curKcal - GermExposureTuning.KCAL_LOST_VOMIT);
+                }
             }
 
             private void FinishedVomit()

--- a/DiseasesReimagined/mod_info.yaml
+++ b/DiseasesReimagined/mod_info.yaml
@@ -1,4 +1,4 @@
 supportedContent: VANILLA_ID,EXPANSION1_ID
 minimumSupportedBuild: 642443
 APIVersion: 2
-version: 1.12.0
+version: 1.13.0


### PR DESCRIPTION
Prevent a vomit related crash on Bionic Duplicants now that they can actually contract diseases.